### PR TITLE
Added a Generic GetAs[T any] function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/iv-p/mapaccess
 
-go 1.13
+go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/iv-p/mapaccess
+module github.com/theouteredge/mapaccess
 
 go 1.18

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/theouteredge/mapaccess
+module github.com/iv-p/mapaccess
 
 go 1.18

--- a/mapaccess.go
+++ b/mapaccess.go
@@ -24,6 +24,21 @@ func Get(data interface{}, key string) (interface{}, error) {
 	return state, nil
 }
 
+// GetAs returns the corresponding key from the map and converts it to type T
+func GetAs[T any](data interface{}, key string) (T, error) {
+	if val, err := Get(data, key); err != nil {
+		var zero T
+		return zero, err
+
+	} else {
+		if res, ok := val.(T); ok {
+			return res, nil
+		}
+		var zero T
+		return zero, fmt.Errorf("expected type %s but got %s", reflect.TypeOf(zero), reflect.TypeOf(val))
+	}
+}
+
 func get(data interface{}, key token) (interface{}, error) {
 	switch state := data.(type) {
 	case map[string]interface{}:

--- a/readme.md
+++ b/readme.md
@@ -28,9 +28,11 @@ It is intended towards using with serializing arbitary JSON and getting an arbit
 j := []byte(`{
     "id": "9b92b11b-b57f-4fa6-af5e-e35a290dc764",	
     "name": "John Doe",
+    "age": 44,
     "friends": [
         {
-            "name": "Jaime Mckinney"
+            "name": "Jaime Mckinney",
+            "age": 41
         },
         {
             "name": "Evangeline Alvarado"
@@ -87,6 +89,17 @@ mapaccess.Get(data, "friends[0][1].name")
 // Invalid
 mapaccess.Get(data, "[0].[1]")
 mapaccess.Get(data, "friends[0].[1]")
+```
+
+### Generic GetAs[T any] Method
+The `GetAs[T any]` method allows you too simplify accessing maps by casting the extraced value to a concrete type
+```go
+// Valid
+mapaccess.GetAs[string](data, "id")
+mapaccess.GetAs[string](data, "name")
+mapaccess.GetAs[int](data, "age")
+mapaccess.GetAs[string](data, "friends[0].name")
+mapaccess.GetAs[int](data, "friends[0].age")
 ```
 
 ## Valid keys


### PR DESCRIPTION
Added a generic GetAs[T any] function to the API's interface, allowing users to extract the values from the maps as concrete types
```
m := map[string]interface{}{
  "name": "Andy",
  "age": 44
}

name, _ := GetAs[string](m, "name")
namel == "Andy"

age, _ := GetAs[int](m, "age")
age == 44
```

This simplifies access to the maps as the user does not have to keep casting the returned interface{} to the simple types they need in their code